### PR TITLE
feat: 新增股票購買功能

### DIFF
--- a/backend/controllers/stock.controller.js
+++ b/backend/controllers/stock.controller.js
@@ -2,7 +2,13 @@
 import axios from 'axios';
 import Stock from '../models/stock.model.js';
 import catchAsyncErrors from '../middlewares/catchAsyncErrors.js';
+import Purchase from '../models/purchase.model.js';
 
+
+// TODO: 取得股票資訊
+// Route: GET /api/stock
+// Desc: 取得股票資訊
+// Access: Public
 export const getStockInfo = catchAsyncErrors(async (req, res, next) => {
   try {
     const { ex_ch } = req.query;
@@ -51,6 +57,36 @@ export const getStockInfo = catchAsyncErrors(async (req, res, next) => {
     const allStocks = [...tseStocks, ...otcStocks];
 
     res.status(200).json(allStocks);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// TODO: 購買
+// Route: POST /api/purchase
+// Desc: 購買股票
+// Access: Private
+export const purchaseStock = catchAsyncErrors(async (req, res, next) => {
+  const { stockCode, stockData, quantity, price } = req.body;
+  const userId = req.user._id; // 從驗證中獲取使用者ID
+
+  try {
+    const purchase = new Purchase({ stockCode, stockData, quantity, price, user: userId });
+    await purchase.save();
+
+    // 購買成功後，返回購買的詳細資訊
+    res.status(201).json({
+      message: '購買成功',
+      purchase: {
+        _id: purchase._id,
+        stockCode: purchase.stockCode,
+        stockData: purchase.stockData,
+        quantity: purchase.quantity,
+        price: purchase.price,
+        timestamp: purchase.timestamp,
+        user: purchase.user // 如果需要使用者資訊，可以將其包含在回應中
+      }
+    });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/backend/models/purchase.model.js
+++ b/backend/models/purchase.model.js
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+
+const purchaseSchema = new mongoose.Schema({
+  stockCode: {
+    type: String,
+    required: true
+  },
+  stockData: {
+    type: String,
+    required: true
+  },
+  quantity: {
+    type: Number,
+    required: true
+  },
+  price: {
+    type: Number,
+    required: true
+  },
+  timestamp: {
+    type: Date,
+    default: Date.now
+  },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+  },
+});
+
+export default mongoose.model('Purchase', purchaseSchema);

--- a/backend/routes/stock.routes.js
+++ b/backend/routes/stock.routes.js
@@ -1,9 +1,11 @@
 // routes/stock.routes.js
 import express from 'express';
-import { getStockInfo } from '../controllers/stock.controller.js';
+import { getStockInfo, purchaseStock} from '../controllers/stock.controller.js';
+import { isAuthenticatedUser } from "../middlewares/auth.js";
 
 const router = express.Router();
 
 router.get('/stocks', getStockInfo);
+router.post('/buy', isAuthenticatedUser, purchaseStock);
 
 export default router;


### PR DESCRIPTION
根據最近的程式碼更改，新增了股票購買功能。這個功能允許使用者購買股票，並將購買的詳細資訊保存到資料庫中。這個功能需要使用者驗證，只有登入的使用者才能進行購買操作。

這個功能的路由是`POST /api/purchase`，並且需要使用者提供股票代碼、股票資料、數量和價格等資訊。在購買成功後，會返回購買的詳細資訊。

這個功能的新增可以提供更完整的股票交易體驗，並且方便使用者進行股票購買操作。